### PR TITLE
Update the chart to not stack the y axis

### DIFF
--- a/dashboard/src/View.elm
+++ b/dashboard/src/View.elm
@@ -76,7 +76,7 @@ chartConfig model =
     , events = Events.hoverMany Hint
     , junk = Junk.hoverMany model.hinted formatTimestamp formatSpeed
     , grid = Grid.default
-    , area = Area.stacked 0.3
+    , area = Area.normal 0.3
     , line = Line.default
     , dots = Dots.default
     }


### PR DESCRIPTION
Currently the chart area is summing up the upload/download values and the y lines are "wrong".

For instance, with download speed of 93Mbps and 22Mbps upload, the download line is rendered at 115Mbps.

This edit changes this behavior, not stacking both values so each line will be at the correct mark.

Before:
![screenshot 2018-07-19 12 58 51](https://user-images.githubusercontent.com/332276/42955052-d1784944-8b53-11e8-91b3-7d8a6361b331.png)

After:
![screenshot 2018-07-19 12 59 44](https://user-images.githubusercontent.com/332276/42955127-db74d084-8b53-11e8-87fd-dd3658baca85.png)
